### PR TITLE
Pin bindown metadata to release tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,7 +102,7 @@ jobs:
           mkdir -p "$(dirname "$CONFIG_FILE")"
           echo '{}' > "$CONFIG_FILE"
           yes '' | script/bindown dependency add-by-github-release \
-            "$GITHUB_REPOSITORY" \
+            "$GITHUB_REPOSITORY@$RELEASE_TAG" \
             --configfile "$CONFIG_FILE" \
             --experimental
           bin/gh release upload "$RELEASE_TAG" "$CONFIG_FILE"


### PR DESCRIPTION
## Summary

- generate the release bindown template from the explicit release tag
- avoid resolving stale metadata from GitHub's latest-release endpoint immediately after publication

## Context

The v0.2.0 release generated a `bindown.yaml` that was byte-identical to v0.1.0 because `add-by-github-release` resolved v0.1.0 as latest. Passing `@$RELEASE_TAG` ensures the generated version and checksums belong to the release being published.

## Testing

- generated bindown metadata locally using `WillAbides/jsonschematogo@v0.2.0` and confirmed it selected v0.2.0 artifacts and checksums